### PR TITLE
feat: mostro daily analysis before wine process starts

### DIFF
--- a/app/(tabs)/tankControl.tsx
+++ b/app/(tabs)/tankControl.tsx
@@ -16,12 +16,14 @@ import {
 } from "react-native";
 
 interface CardProps {
-  id: number;
+  depositId: number;
   title: string;
   isAvailable: boolean | string;
-  density?: string;
+  density?: 0;
   temperature?: number;
   pressure?: 0;
+  content?: string;
+  contentId?: number;
 }
 
 function FilterDrawer({
@@ -59,20 +61,28 @@ function FilterDrawer({
 function Card({
   title,
   isAvailable,
-  density = "",
+  density = 0,
   temperature = 0,
   pressure = 0,
-  id = 0,
+  depositId,
+  content = "",
+  contentId = 0,
 }: CardProps) {
   const href =
     isAvailable != "Edge"
       ? {
           pathname: "/(tankControl)/[emptyTank]",
-          params: { tank: title, id: id },
+          params: { tank: title, depositId: depositId },
         }
-      : { pathname: "/tank/[tank]", params: { tank: title, id: id } };
-
-  console.log(id);
+      : {
+          pathname: "/tank/[tank]",
+          params: {
+            tank: title,
+            depositId: depositId,
+            content: content,
+            contentId: contentId,
+          },
+        };
 
   return (
     <Link href={href as Href} asChild>
@@ -94,7 +104,7 @@ function Card({
               </View>
             )}
           </View>
-          {!isAvailable && (
+          {isAvailable === "Edge" && temperature ? (
             <>
               <View className="w-full h-[1px] bg-neutral-250"></View>
               <View className="p-4">
@@ -118,18 +128,22 @@ function Card({
                     </Text>
                   </View>
                 </View>
-                <View className="flex-row justify-between">
-                  <Text className="text-xl font-light">Pressão:</Text>
-                  <View className="flex-row justify-center items-end">
-                    <Text className="text-2xl font-semibold">{pressure} </Text>
-                    <Text className="text-base font-normal text-neutral-400">
-                      Pa
-                    </Text>
+                {pressure && (
+                  <View className="flex-row justify-between">
+                    <Text className="text-xl font-light">Pressão:</Text>
+                    <View className="flex-row justify-center items-end">
+                      <Text className="text-2xl font-semibold">
+                        {pressure}{" "}
+                      </Text>
+                      <Text className="text-base font-normal text-neutral-400">
+                        Pa
+                      </Text>
+                    </View>
                   </View>
-                </View>
+                )}
               </View>
             </>
-          )}
+          ) : null}
         </View>
       </TouchableOpacity>
     </Link>
@@ -160,7 +174,6 @@ export default function TankControl() {
           },
         }
       );
-      console.log(response.data);
       setData(response.data);
     } catch (error) {
       console.error("Erro ao buscar depósitos:", error);
@@ -214,22 +227,35 @@ export default function TankControl() {
             keyExtractor={(item) => item.deposito}
             renderItem={({ item }) => {
               if (item.conteudo != null) {
-                return (
+                return item.temperatura ? (
                   <Card
-                    id={item.idDeposito}
+                    depositId={item.idDeposito}
                     title={item.deposito}
                     isAvailable={"Edge"}
+                    content={item.conteudo}
+                    contentId={item.idConteudo}
+                    density={item.densidade}
+                    temperature={item.temperatura}
+                    pressure={item.pressao ? item.pressao : null}
+                  />
+                ) : (
+                  <Card
+                    depositId={item.idDeposito}
+                    title={item.deposito}
+                    isAvailable={"Edge"}
+                    content={item.conteudo}
+                    contentId={item.idConteudo}
                   />
                 );
               } else {
                 return (
                   <Card
-                    id={item.idDeposito}
+                    depositId={item.idDeposito}
                     title={item.deposito}
                     isAvailable={
                       item.tempMostro == null ? true : item.tempMostro
                     }
-                    density={"0"}
+                    density={0}
                     temperature={20}
                     pressure={item.pressure === 0 ? 0 : undefined}
                   />

--- a/app/(tankControl)/[emptyTank].tsx
+++ b/app/(tankControl)/[emptyTank].tsx
@@ -13,32 +13,28 @@ import React, { useCallback } from "react";
 import { FlatList, Text, View } from "react-native";
 
 export default function EmptyTank() {
-  const { tank, id } = useLocalSearchParams();
+  const { tank, depositId } = useLocalSearchParams();
 
   const activityListItems = [
     {
       name: "Adicionar Vinho Base",
       icon: <GrapeIcon size={28} color="#000000" />,
       route: "/(tankControl)/tank/addBaseWine/[addBaseWine]",
-      type: "tank",
-      param: [{ tank: tank as string, id: Number(id) }],
+      param: [{ tank: tank as string, depositId: Number(depositId) }],
     },
     {
       name: "Realizar Trasfega",
       icon: <ArrowRightLeft size={28} color="#000000" />,
       route: "/(tankControl)/tank/realizarTrasfega/[trasfega]",
-      type: "tank",
-      param: [{ tank: tank as string, id: Number(id) }],
+      param: [{ tank: tank as string, depositId: Number(depositId) }],
     },
     {
       name: "Iniciar pé de Cuba",
       icon: <Grape size={28} color="#000000" />,
       route: "/(tankControl)/tank/addPeDeCuba/[addPeDeCuba]",
-      type: "tank",
-      param: [{ tank: tank as string, id: Number(id) }],
+      param: [{ tank: tank as string, depositId: Number(depositId) }],
     },
   ];
-
   const { clearShipments } = useShipmentStore();
 
   useFocusEffect(
@@ -68,7 +64,7 @@ export default function EmptyTank() {
               title={item.name}
               icon={item.icon}
               route={item.route}
-              type={item.type}
+              //type={item.type}
               param={item.param}
             />
           )}

--- a/app/(tankControl)/tank/[tank].tsx
+++ b/app/(tankControl)/tank/[tank].tsx
@@ -15,7 +15,7 @@ import React, { useCallback } from "react";
 import { FlatList, StyleSheet, Text, View } from "react-native";
 
 export default function Tank() {
-  const { tank, id } = useLocalSearchParams();
+  const { tank, depositId, content, contentId } = useLocalSearchParams();
   const router = useRouter();
   const { clearShipments } = useShipmentStore();
 
@@ -25,48 +25,60 @@ export default function Tank() {
       return;
     }, [])
   );
-
   const activityListItems = [
     {
       name: "Análises diárias",
       icon: <Cylinder size="28px" color="#000000" />,
       route: "/(tankControl)/tank/dailyAnalysis/[dailyAnalysis]",
-      type: "tank",
-      param: [{ tank: tank as string, id: Number(id) }],
+      //type: "tank",
+      param: [
+        {
+          tank: tank as string,
+          depositId: Number(depositId),
+          content: content,
+          contentId: contentId,
+        },
+      ],
     },
     {
       name: "Análises de deposito",
       icon: <Microscope size="28px" color="#000000" />,
       route: "/(tankControl)/tank/depositAnalysis/listAnalysis/[listAnalysis]",
-      type: "tank",
-      param: [{ tank: tank as string, id: Number(id) }],
+      //type: "tank",
+      param: [{ tank: tank as string, depositId: Number(depositId) }],
     },
     {
       name: "Envase e rotulagem",
       icon: <Milk size="28px" color="#000000" />,
       route: "/envaseERotulagem/envase",
-      param: [{ tank: tank as string, id: Number(id) }],
+      //type: "tank",
+      param: [{ tank: tank as string, depositId: Number(depositId) }],
     },
     {
       name: "Adicionar Vinho Base",
       icon: <Grape size="28px" color="#000000" />,
       route: "/(tankControl)/tank/addBaseWine/[addBaseWine]",
-      type: "tank",
-      param: [{ tank: tank as string, id: Number(id) }],
+      //type: "tank",
+      param: [{ tank: tank as string, depositId: Number(depositId) }],
     },
     {
       name: "Realizar Trasfega",
       icon: <ArrowRightLeft size="28px" color="#000000" />,
       route: "/(tankControl)/tank/realizarTrasfega/[trasfega]",
-      type: "",
-      param: [{ tank: tank as string, id: Number(id) }],
+      //type: "",
+      param: [{ tank: tank as string, depositId: Number(depositId) }],
     },
     {
       name: "Adicionar pé de Cuba",
       icon: <Grape size="28px" color="#000000" />,
       route: "/(tankControl)/tank/addPeDeCuba/[addPeDeCuba]",
-      type: "tank",
-      param: [{ tank: tank as string, id: Number(id) }],
+      //type: "tank",
+      param: [
+        {
+          tank: tank as string,
+          depositId: Number(depositId),
+        },
+      ],
     },
   ];
 
@@ -91,7 +103,7 @@ export default function Tank() {
                 title={item.name}
                 icon={item.icon}
                 route={item.route}
-                type={item.type}
+                //type={item.type}
                 param={item.param}
               />
             );

--- a/app/(tankControl)/tank/addBaseWine/[baseWine].tsx
+++ b/app/(tankControl)/tank/addBaseWine/[baseWine].tsx
@@ -16,12 +16,9 @@ import * as SecureStore from "expo-secure-store";
 import React, { useCallback, useState } from "react";
 import { FlatList, Text, View } from "react-native";
 
-//TODO: TERMINAR A PARTE DE ASSOCIAÇÃO DA REMESSA COM O DEPOSITO QUANDO FOR
-//DEDICIDO O QUE É PRA FAZER
-
 export default function BaseWine() {
   const router = useRouter();
-  const { tank, id } = useLocalSearchParams();
+  const { tank, depositId } = useLocalSearchParams();
   const [data, setData] = useState();
   const selectedShipments = useShipmentStore(
     (state) => state.selectedShipments
@@ -55,7 +52,7 @@ export default function BaseWine() {
     const token = await SecureStore.getItemAsync("user-token");
     const data = {
       remessaUvaIdList: selectedShipments,
-      depositoId: id,
+      depositoId: depositId,
       funcionarioId: userId,
     };
     apiInstance
@@ -65,8 +62,17 @@ export default function BaseWine() {
         },
       })
       .then((res) => {
-        console.log(res.data);
+        const data = res.data;
         clearShipments();
+        router.navigate({
+          pathname: "/tank/[tank]",
+          params: {
+            tank: tank as string,
+            depositId: data.depositoId,
+            content: "Mostro",
+            contentId: data.mostroId,
+          },
+        });
       })
       .catch((err) => {
         console.log(err.request);

--- a/components/ActivityCard.tsx
+++ b/components/ActivityCard.tsx
@@ -6,10 +6,12 @@ interface ActivityCardProps {
   icon: any;
   title: string;
   route: string | any;
-  type?: string;
+  // type?: string;
   param?: {
     tank: string;
-    id?: number;
+    depositId?: number;
+    content?: string;
+    contentId?: number;
   }[];
 }
 
@@ -17,7 +19,7 @@ export default function ActivityCard({
   icon,
   title,
   route,
-  type = "",
+  //type = "",
   param = [],
 }: ActivityCardProps) {
   const href =


### PR DESCRIPTION
- implements the daily analysis funcionality when the tank has mostro in it. 
- modified the url params to "/tank/[tank]" route adding content and contentId because we'll need this info when we call the api to register analysis information. 
- modified the tankControl page too, now when the tank is occupied and has at least one analysis the data from the analysis will show up.
- we need to see how to handle the return functionality better, because when we associate a grape shipment to a empty tank, we will get redirected to the occupied tank page. the problem occurs when we try to go back using the left arrow on the top bar, we will get redirected to the add grape shipment > empty tank page > tank control, i.e, all the pages that are in the navigation stack.